### PR TITLE
fix error when was trying to import this check into Intellij IDEA Checksum plugin

### DIFF
--- a/Android/checkstyle/checkstyle.xml
+++ b/Android/checkstyle/checkstyle.xml
@@ -1,172 +1,159 @@
-<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE module PUBLIC
-    "-//Puppy Crawl//DTD Check Configuration 1.2//EN"
-    "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
-
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE module
+    PUBLIC '-//Puppy Crawl//DTD Check Configuration 1.2//EN'
+    'http://www.puppycrawl.com/dtds/configuration_1_2.dtd'>
 <module name="Checker">
-    <module name="FileTabCharacter" />
-    <module name="NewlineAtEndOfFile" />
+    <module name="FileTabCharacter"/>
+    <module name="NewlineAtEndOfFile"/>
     <module name="RegexpSingleline">
-        <property name="message" value="Line has trailing spaces." />
-        <property name="minimum" value="0" />
-        <property name="maximum" value="0" />
-        <property name="format" value="\s+$" />
-        <property name="ignoreCase" value="true" />
+        <property name="message" value="Line has trailing spaces."/>
+        <property name="minimum" value="0"/>
+        <property name="maximum" value="0"/>
+        <property name="format" value="\s+$"/>
+        <property name="ignoreCase" value="true"/>
     </module>
     <module name="SuppressionCommentFilter">
-        <property name="offCommentFormat" value="CS\:OFF" />
-        <property name="onCommentFormat" value="CS\:ON" />
+        <property name="offCommentFormat" value="CS\:OFF"/>
+        <property name="onCommentFormat" value="CS\:ON"/>
     </module>
     <!-- source: https://stackoverflow.com/questions/6410155/how-to-disable-a-particular-checkstyle-rule-for-a-particular-line-of-code -->
     <module name="SuppressWithNearbyCommentFilter">
-        <property name="commentFormat" value="CS\:OFF ([\w\|]+) FOR (-?\d+) LINES" />
-        <property name="checkFormat" value="$1" />
-        <property name="influenceFormat" value="$2" />
+        <property name="commentFormat" value="CS\:OFF ([\w\|]+) FOR (-?\d+) LINES"/>
+        <property name="checkFormat" value="$1"/>
+        <property name="influenceFormat" value="$2"/>
     </module>
     <module name="SuppressionFilter">
-        <property name="file" value="${checkstyleConfigDir}/checkstyle-suppressions.xml" />
+        <property name="file" value="${checkstyleConfigDir}/checkstyle-suppressions.xml"/>
     </module>
     <module name="TreeWalker">
-        <property name="tabWidth" value="1" />
+        <property name="tabWidth" value="1"/>
         <!-- start of javadoc rules built using http://checkstyle.sourceforge.net/config_javadoc.html -->
         <module name="JavadocType">
-            <property name="scope" value="private" />
+            <property name="scope" value="private"/>
         </module>
-
         <module name="JavadocMethod">
-            <property name="scope" value="public" />
-            <property name="allowMissingParamTags" value="true" />
-            <property name="allowMissingThrowsTags" value="true" />
-            <property name="allowMissingPropertyJavadoc" value="true" />
+            <property name="scope" value="public"/>
+            <property name="allowMissingParamTags" value="true"/>
+            <property name="allowMissingThrowsTags" value="true"/>
+            <property name="allowMissingPropertyJavadoc" value="true"/>
         </module>
-
         <module name="JavadocStyle">
-            <property name="scope" value="private" />
-            <property name="checkFirstSentence" value="true" />
-            <property name="checkEmptyJavadoc" value="true" />
+            <property name="scope" value="private"/>
+            <property name="checkFirstSentence" value="true"/>
+            <property name="checkEmptyJavadoc" value="true"/>
         </module>
-        -->
         <!-- end of javadoc rules -->
-
-        <module name="FileContentsHolder" />
+        <module name="FileContentsHolder"/>
         <module name="ArrayTypeStyle">
-            <property name="javaStyle" value="true" />
-        </module>
+            <property name="javaStyle" value="true"/></module>
         <module name="AvoidNestedBlocks">
-            <property name="allowInSwitchCase" value="true" />
+            <property name="allowInSwitchCase" value="true"/>
         </module>
         <module name="AvoidStarImport">
-            <property name="excludes" value="org.junit.*" />
-            <property name="allowClassImports" value="false" />
-            <property name="allowStaticMemberImports" value="false" />
+            <property name="excludes" value="org.junit.*"/>
+            <property name="allowClassImports" value="false"/>
+            <property name="allowStaticMemberImports" value="false"/>
         </module>
-        <module name="BooleanExpressionComplexity" />
-        <module name="ClassDataAbstractionCoupling" />
-        <module name="ConstantName" />
-        <module name="DeclarationOrder" />
-        <!--      <property name="ignoreConstructors" value="false" />
-              <property name="ignoreMethods" value="false" />
-              <property name="ignoreModifiers" value="false" />
-            </module>-->
-        <module name="DefaultComesLast" />
+        <module name="BooleanExpressionComplexity"/>
+        <module name="ClassDataAbstractionCoupling"/>
+        <module name="ConstantName"/>
+        <module name="DeclarationOrder"/>
+        <!--      <property name="ignoreConstructors" value="false" /><property name="ignoreMethods" value="false" /><property name="ignoreModifiers" value="false" /></module>-->
+        <module name="DefaultComesLast"/>
         <!--<module name="DoubleCheckedLocking"/>-->
-        <module name="EmptyForIteratorPad" />
-        <module name="EmptyStatement" />
-        <module name="EqualsHashCode" />
-        <module name="FallThrough" />
-        <module name="FinalClass" />
-        <module name="GenericWhitespace" />
-        <module name="HiddenField" />
-        <module name="HideUtilityClassConstructor" />
-        <module name="IllegalCatch" />
-        <module name="IllegalImport" />
-        <module name="IllegalInstantiation" />
-        <module name="InnerAssignment" />
+        <module name="EmptyForIteratorPad"/>
+        <module name="EmptyStatement"/>
+        <module name="EqualsHashCode"/>
+        <module name="FallThrough"/>
+        <module name="FinalClass"/>
+        <module name="GenericWhitespace"/>
+        <module name="HiddenField"/>
+        <module name="HideUtilityClassConstructor"/>
+        <module name="IllegalCatch"/>
+        <module name="IllegalImport"/>
+        <module name="IllegalInstantiation"/>
+        <module name="InnerAssignment"/>
         <module name="InterfaceIsType">
-            <property name="allowMarkerInterfaces" value="true" />
+            <property name="allowMarkerInterfaces" value="true"/>
         </module>
-        <module name="LeftCurly" />
-
+        <module name="LeftCurly"/>
         <!-- Based on: http://code.google.com/p/google-api-java-client/source/browse/checkstyle.xml -->
         <module name="LineLength">
             <!-- Checks if a line is too long. -->
-            <property name="ignorePattern"
-                value="^(package .*;\s*)|(import .*;\s*)|( *\* *https?://.*)|( *// *https?://.*)$" />
-            <property name="max" value="100" />
-            <property name="severity" value="error" />
+            <property name="ignorePattern" value="^(package .*;\s*)|(import .*;\s*)|( *\* *https?://.*)|( *// *https?://.*)$"/>
+            <property name="max" value="100"/>
+            <property name="severity" value="error"/>
         </module>
-        <module name="LocalFinalVariableName" />
-        <module name="LocalVariableName" />
+        <module name="LocalFinalVariableName"/>
+        <module name="LocalVariableName"/>
         <module name="MagicNumber">
-            <property name="ignoreNumbers" value="-1.0,0.0,1.0,2.0" />
-            <property name="ignoreHashCodeMethod" value="false" />
-            <property name="ignoreAnnotation" value="false" />
+            <property name="ignoreNumbers" value="-1.0,0.0,1.0,2.0"/>
+            <property name="ignoreHashCodeMethod" value="false"/>
+            <property name="ignoreAnnotation" value="false"/>
         </module>
         <!-- Defined here:http://source.android.com/source/code-style.html,
              Implemented here: https://github.com/unchiujar/Umbra/blob/master/dev/android_cs.xml -->
         <module name="MemberName">
-            <metadata name="net.sf.eclipsecs.core.comment"
-                value="non public members should start with m"></metadata>
-            <property name="applyToPublic" value="false"></property>
-            <property name="format" value="^m[a-zA-Z0-9]*$"></property>
+            <metadata name="net.sf.eclipsecs.core.comment" value="non public members should start with m"/>
+            <property name="applyToPublic" value="false"/>
+            <property name="format" value="^m[a-zA-Z0-9]*$"/>
         </module>
-        <module name="MethodName" />
-        <module name="MethodParamPad" />
-        <module name="MissingDeprecated" />
-        <module name="MissingOverride" />
-        <module name="MissingSwitchDefault" />
-        <module name="ModifierOrder" />
+        <module name="MethodName"/>
+        <module name="MethodParamPad"/>
+        <module name="MissingDeprecated"/>
+        <module name="MissingOverride"/>
+        <module name="MissingSwitchDefault"/>
+        <module name="ModifierOrder"/>
         <module name="MultipleStringLiterals">
-            <property name="allowedDuplicates" value="2" />
+            <property name="allowedDuplicates" value="2"/>
         </module>
-        <module name="MultipleVariableDeclarations" />
-        <module name="MutableException" />
-        <module name="NeedBraces" />
-        <module name="NoClone" />
-        <module name="NoWhitespaceAfter" />
-        <module name="NoWhitespaceBefore" />
+        <module name="MultipleVariableDeclarations"/>
+        <module name="MutableException"/>
+        <module name="NeedBraces"/>
+        <module name="NoClone"/>
+        <module name="NoWhitespaceAfter"/>
+        <module name="NoWhitespaceBefore"/>
         <!-- ternary operator is allowed on one line -->
         <module name="OperatorWrap">
-            <property name="option" value="eol" />
-            <property name="tokens" value="BAND, BOR, BSR, BXOR, DIV, EQUAL, GE, GT, LAND, LE, LITERAL_INSTANCEOF, LOR, LT,
-          MINUS, MOD, NOT_EQUAL, PLUS, QUESTION, SL, SR, STAR" />
+            <property name="option" value="eol"/>
+            <property name="tokens" value="BAND, BOR, BSR, BXOR, DIV, EQUAL, GE, GT, LAND, LE, LITERAL_INSTANCEOF, LOR, LT,           MINUS, MOD, NOT_EQUAL, PLUS, QUESTION, SL, SR, STAR"/>
         </module>
-        <module name="PackageName" />
-        <module name="ParameterAssignment" />
-        <module name="ParameterName" />
-        <module name="ParenPad" />
-        <module name="RedundantImport" />
-        <module name="RedundantModifier" />
-        <module name="RedundantThrows" />
+        <module name="PackageName"/>
+        <module name="ParameterAssignment"/>
+        <module name="ParameterName"/>
+        <module name="ParenPad"/>
+        <module name="RedundantImport"/>
+        <module name="RedundantModifier"/>
+        <module name="RedundantThrows"/>
         <module name="ReturnCount">
-            <property name="max" value="3" />
+            <property name="max" value="3"/>
         </module>
-        <module name="RightCurly" />
-        <module name="SimplifyBooleanExpression" />
-        <module name="SimplifyBooleanReturn" />
+        <module name="RightCurly"/>
+        <module name="SimplifyBooleanExpression"/>
+        <module name="SimplifyBooleanReturn"/>
         <module name="StaticVariableName">
-            <metadata name="net.sf.eclipsecs.core.comment" value="starts with 's'"></metadata>
-            <property name="format" value="^s[a-zA-Z0-9]*$"></property>
+            <metadata name="net.sf.eclipsecs.core.comment" value="starts with 's'"/>
+            <property name="format" value="^s[a-zA-Z0-9]*$"/>
         </module>
-        <module name="StringLiteralEquality" />
-        <module name="TrailingComment" />
-        <module name="TypeName" />
-        <module name="TypecastParenPad" />
+        <module name="StringLiteralEquality"/>
+        <module name="TrailingComment"/>
+        <module name="TypeName"/>
+        <module name="TypecastParenPad"/>
         <module name="UncommentedMain">
-            <property name="excludedClasses" value="\.Main$" />
+            <property name="excludedClasses" value="\.Main$"/>
         </module>
         <module name="UnusedImports">
-            <property name="processJavadoc" value="false" />
+            <property name="processJavadoc" value="false"/>
         </module>
-        <module name="UpperEll" />
+        <module name="UpperEll"/>
         <module name="VisibilityModifier">
-            <property name="packageAllowed" value="true" />
-            <property name="protectedAllowed" value="true" />
+            <property name="packageAllowed" value="true"/>
+            <property name="protectedAllowed" value="true"/>
         </module>
-        <module name="WhitespaceAfter" />
+        <module name="WhitespaceAfter"/>
         <module name="WhitespaceAround">
-            <property name="allowEmptyMethods" value="true" />
-            <property name="allowEmptyConstructors" value="true" />
+            <property name="allowEmptyMethods" value="true"/>
+            <property name="allowEmptyConstructors" value="true"/>
         </module>
     </module>
 </module>
-


### PR DESCRIPTION
I tried to use this checkstyle file for IntelliJ IDEA, but was getting "The content of element type "module" must match "(module|property|metadata)*"." error. I got the same error when I tried to validate this XML in [Online XML Validator](http://www.xmlvalidation.com/). When I removed empty spaces and reformatted file a bit, it started to work, so I thought to add this fix to the repository so everyone could use it as well. 