### PR TITLE
Make checkstyle work With Intellij IDEA 2016.3 and CheckStyle 6.5 and up

### DIFF
--- a/Android/checkstyle/checkstyle.xml
+++ b/Android/checkstyle/checkstyle.xml
@@ -1,172 +1,159 @@
-<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE module PUBLIC
-    "-//Puppy Crawl//DTD Check Configuration 1.2//EN"
-    "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
-
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE module
+    PUBLIC '-//Puppy Crawl//DTD Check Configuration 1.2//EN'
+    'http://www.puppycrawl.com/dtds/configuration_1_2.dtd'>
 <module name="Checker">
-    <module name="FileTabCharacter" />
-    <module name="NewlineAtEndOfFile" />
+    <module name="FileTabCharacter"/>
+    <module name="NewlineAtEndOfFile"/>
     <module name="RegexpSingleline">
-        <property name="message" value="Line has trailing spaces." />
-        <property name="minimum" value="0" />
-        <property name="maximum" value="0" />
-        <property name="format" value="\s+$" />
-        <property name="ignoreCase" value="true" />
+        <property name="message" value="Line has trailing spaces."/>
+        <property name="minimum" value="0"/>
+        <property name="maximum" value="0"/>
+        <property name="format" value="\s+$"/>
+        <property name="ignoreCase" value="true"/>
     </module>
     <module name="SuppressionCommentFilter">
-        <property name="offCommentFormat" value="CS\:OFF" />
-        <property name="onCommentFormat" value="CS\:ON" />
+        <property name="offCommentFormat" value="CS\:OFF"/>
+        <property name="onCommentFormat" value="CS\:ON"/>
     </module>
     <!-- source: https://stackoverflow.com/questions/6410155/how-to-disable-a-particular-checkstyle-rule-for-a-particular-line-of-code -->
     <module name="SuppressWithNearbyCommentFilter">
-        <property name="commentFormat" value="CS\:OFF ([\w\|]+) FOR (-?\d+) LINES" />
-        <property name="checkFormat" value="$1" />
-        <property name="influenceFormat" value="$2" />
+        <property name="commentFormat" value="CS\:OFF ([\w\|]+) FOR (-?\d+) LINES"/>
+        <property name="checkFormat" value="$1"/>
+        <property name="influenceFormat" value="$2"/>
     </module>
     <module name="SuppressionFilter">
-        <property name="file" value="${checkstyleConfigDir}/checkstyle-suppressions.xml" />
+        <property name="file" value="${checkstyleConfigDir}/checkstyle-suppressions.xml"/>
     </module>
     <module name="TreeWalker">
-        <property name="tabWidth" value="1" />
+        <property name="tabWidth" value="1"/>
         <!-- start of javadoc rules built using http://checkstyle.sourceforge.net/config_javadoc.html -->
         <module name="JavadocType">
-            <property name="scope" value="private" />
+            <property name="scope" value="private"/>
         </module>
-
         <module name="JavadocMethod">
-            <property name="scope" value="public" />
-            <property name="allowMissingParamTags" value="true" />
-            <property name="allowMissingThrowsTags" value="true" />
-            <property name="allowMissingPropertyJavadoc" value="true" />
+            <property name="scope" value="public"/>
+            <property name="allowMissingParamTags" value="true"/>
+            <property name="allowMissingThrowsTags" value="true"/>
+            <property name="allowMissingPropertyJavadoc" value="true"/>
         </module>
-
         <module name="JavadocStyle">
-            <property name="scope" value="private" />
-            <property name="checkFirstSentence" value="true" />
-            <property name="checkEmptyJavadoc" value="true" />
+            <property name="scope" value="private"/>
+            <property name="checkFirstSentence" value="true"/>
+            <property name="checkEmptyJavadoc" value="true"/>
         </module>
-        -->
         <!-- end of javadoc rules -->
-
-        <module name="FileContentsHolder" />
+        <module name="FileContentsHolder"/>
         <module name="ArrayTypeStyle">
-            <property name="javaStyle" value="true" />
-        </module>
+            <property name="javaStyle" value="true"/></module>
         <module name="AvoidNestedBlocks">
-            <property name="allowInSwitchCase" value="true" />
+            <property name="allowInSwitchCase" value="true"/>
         </module>
         <module name="AvoidStarImport">
-            <property name="excludes" value="org.junit.*" />
-            <property name="allowClassImports" value="false" />
-            <property name="allowStaticMemberImports" value="false" />
+            <property name="excludes" value="org.junit.*"/>
+            <property name="allowClassImports" value="false"/>
+            <property name="allowStaticMemberImports" value="false"/>
         </module>
-        <module name="BooleanExpressionComplexity" />
-        <module name="ClassDataAbstractionCoupling" />
-        <module name="ConstantName" />
-        <module name="DeclarationOrder" />
-        <!--      <property name="ignoreConstructors" value="false" />
-              <property name="ignoreMethods" value="false" />
-              <property name="ignoreModifiers" value="false" />
-            </module>-->
-        <module name="DefaultComesLast" />
+        <module name="BooleanExpressionComplexity"/>
+        <module name="ClassDataAbstractionCoupling"/>
+        <module name="ConstantName"/>
+        <module name="DeclarationOrder"/>
+        <!--      <property name="ignoreConstructors" value="false" /><property name="ignoreMethods" value="false" /><property name="ignoreModifiers" value="false" /></module>-->
+        <module name="DefaultComesLast"/>
         <!--<module name="DoubleCheckedLocking"/>-->
-        <module name="EmptyForIteratorPad" />
-        <module name="EmptyStatement" />
-        <module name="EqualsHashCode" />
-        <module name="FallThrough" />
-        <module name="FinalClass" />
-        <module name="GenericWhitespace" />
-        <module name="HiddenField" />
-        <module name="HideUtilityClassConstructor" />
-        <module name="IllegalCatch" />
-        <module name="IllegalImport" />
-        <module name="IllegalInstantiation" />
-        <module name="InnerAssignment" />
+        <module name="EmptyForIteratorPad"/>
+        <module name="EmptyStatement"/>
+        <module name="EqualsHashCode"/>
+        <module name="FallThrough"/>
+        <module name="FinalClass"/>
+        <module name="GenericWhitespace"/>
+        <module name="HiddenField"/>
+        <module name="HideUtilityClassConstructor"/>
+        <module name="IllegalCatch"/>
+        <module name="IllegalImport"/>
+        <module name="IllegalInstantiation"/>
+        <module name="InnerAssignment"/>
         <module name="InterfaceIsType">
-            <property name="allowMarkerInterfaces" value="true" />
+            <property name="allowMarkerInterfaces" value="true"/>
         </module>
-        <module name="LeftCurly" />
-
+        <module name="LeftCurly"/>
         <!-- Based on: http://code.google.com/p/google-api-java-client/source/browse/checkstyle.xml -->
         <module name="LineLength">
             <!-- Checks if a line is too long. -->
-            <property name="ignorePattern"
-                value="^(package .*;\s*)|(import .*;\s*)|( *\* *https?://.*)|( *// *https?://.*)$" />
-            <property name="max" value="100" />
-            <property name="severity" value="error" />
+            <property name="ignorePattern" value="^(package .*;\s*)|(import .*;\s*)|( *\* *https?://.*)|( *// *https?://.*)$"/>
+            <property name="max" value="100"/>
+            <property name="severity" value="error"/>
         </module>
-        <module name="LocalFinalVariableName" />
-        <module name="LocalVariableName" />
+        <module name="LocalFinalVariableName"/>
+        <module name="LocalVariableName"/>
         <module name="MagicNumber">
-            <property name="ignoreNumbers" value="-1.0,0.0,1.0,2.0" />
-            <property name="ignoreHashCodeMethod" value="false" />
-            <property name="ignoreAnnotation" value="false" />
+            <property name="ignoreNumbers" value="-1.0,0.0,1.0,2.0"/>
+            <property name="ignoreHashCodeMethod" value="false"/>
+            <property name="ignoreAnnotation" value="false"/>
         </module>
         <!-- Defined here:http://source.android.com/source/code-style.html,
              Implemented here: https://github.com/unchiujar/Umbra/blob/master/dev/android_cs.xml -->
         <module name="MemberName">
-            <metadata name="net.sf.eclipsecs.core.comment"
-                value="non public members should start with m"></metadata>
-            <property name="applyToPublic" value="false"></property>
-            <property name="format" value="^m[a-zA-Z0-9]*$"></property>
+            <metadata name="net.sf.eclipsecs.core.comment" value="non public members should start with m"/>
+            <property name="applyToPublic" value="false"/>
+            <property name="format" value="^m[a-zA-Z0-9]*$"/>
         </module>
-        <module name="MethodName" />
-        <module name="MethodParamPad" />
-        <module name="MissingDeprecated" />
-        <module name="MissingOverride" />
-        <module name="MissingSwitchDefault" />
-        <module name="ModifierOrder" />
+        <module name="MethodName"/>
+        <module name="MethodParamPad"/>
+        <module name="MissingDeprecated"/>
+        <module name="MissingOverride"/>
+        <module name="MissingSwitchDefault"/>
+        <module name="ModifierOrder"/>
         <module name="MultipleStringLiterals">
-            <property name="allowedDuplicates" value="2" />
+            <property name="allowedDuplicates" value="2"/>
         </module>
-        <module name="MultipleVariableDeclarations" />
-        <module name="MutableException" />
-        <module name="NeedBraces" />
-        <module name="NoClone" />
-        <module name="NoWhitespaceAfter" />
-        <module name="NoWhitespaceBefore" />
+        <module name="MultipleVariableDeclarations"/>
+        <module name="MutableException"/>
+        <module name="NeedBraces"/>
+        <module name="NoClone"/>
+        <module name="NoWhitespaceAfter"/>
+        <module name="NoWhitespaceBefore"/>
         <!-- ternary operator is allowed on one line -->
         <module name="OperatorWrap">
-            <property name="option" value="eol" />
-            <property name="tokens" value="BAND, BOR, BSR, BXOR, DIV, EQUAL, GE, GT, LAND, LE, LITERAL_INSTANCEOF, LOR, LT,
-          MINUS, MOD, NOT_EQUAL, PLUS, QUESTION, SL, SR, STAR" />
+            <property name="option" value="eol"/>
+            <property name="tokens" value="BAND, BOR, BSR, BXOR, DIV, EQUAL, GE, GT, LAND, LE, LITERAL_INSTANCEOF, LOR, LT,           MINUS, MOD, NOT_EQUAL, PLUS, QUESTION, SL, SR, STAR"/>
         </module>
-        <module name="PackageName" />
-        <module name="ParameterAssignment" />
-        <module name="ParameterName" />
-        <module name="ParenPad" />
-        <module name="RedundantImport" />
-        <module name="RedundantModifier" />
-        <module name="RedundantThrows" />
+        <module name="PackageName"/>
+        <module name="ParameterAssignment"/>
+        <module name="ParameterName"/>
+        <module name="ParenPad"/>
+        <module name="RedundantImport"/>
+        <module name="RedundantModifier"/>
+        <module name="RedundantThrows"/>
         <module name="ReturnCount">
-            <property name="max" value="3" />
+            <property name="max" value="3"/>
         </module>
-        <module name="RightCurly" />
-        <module name="SimplifyBooleanExpression" />
-        <module name="SimplifyBooleanReturn" />
+        <module name="RightCurly"/>
+        <module name="SimplifyBooleanExpression"/>
+        <module name="SimplifyBooleanReturn"/>
         <module name="StaticVariableName">
-            <metadata name="net.sf.eclipsecs.core.comment" value="starts with 's'"></metadata>
-            <property name="format" value="^s[a-zA-Z0-9]*$"></property>
+            <metadata name="net.sf.eclipsecs.core.comment" value="starts with 's'"/>
+            <property name="format" value="^s[a-zA-Z0-9]*$"/>
         </module>
-        <module name="StringLiteralEquality" />
-        <module name="TrailingComment" />
-        <module name="TypeName" />
-        <module name="TypecastParenPad" />
+        <module name="StringLiteralEquality"/>
+        <module name="TrailingComment"/>
+        <module name="TypeName"/>
+        <module name="TypecastParenPad"/>
         <module name="UncommentedMain">
-            <property name="excludedClasses" value="\.Main$" />
+            <property name="excludedClasses" value="\.Main$"/>
         </module>
         <module name="UnusedImports">
-            <property name="processJavadoc" value="false" />
+            <property name="processJavadoc" value="false"/>
         </module>
-        <module name="UpperEll" />
+        <module name="UpperEll"/>
         <module name="VisibilityModifier">
-            <property name="packageAllowed" value="true" />
-            <property name="protectedAllowed" value="true" />
+            <property name="packageAllowed" value="true"/>
+            <property name="protectedAllowed" value="true"/>
         </module>
-        <module name="WhitespaceAfter" />
+        <module name="WhitespaceAfter"/>
         <module name="WhitespaceAround">
-            <property name="allowEmptyMethods" value="true" />
-            <property name="allowEmptyConstructors" value="true" />
+            <property name="allowEmptyMethods" value="true"/>
+            <property name="allowEmptyConstructors" value="true"/>
         </module>
     </module>
 </module>
-

--- a/Android/checkstyle/checkstyle.xml
+++ b/Android/checkstyle/checkstyle.xml
@@ -124,7 +124,6 @@
         <module name="ParenPad"/>
         <module name="RedundantImport"/>
         <module name="RedundantModifier"/>
-        <module name="RedundantThrows"/>
         <module name="ReturnCount">
             <property name="max" value="3"/>
         </module>


### PR DESCRIPTION
I have faced with 2 problems while adding this checkstyle file to my project in Intellij IDEA : 
1. ```The content of element type "module" must match "(module|property|metadata)*"```. error on adding checkstyle.xml config. I was seeing this problem in [Online XML validator](http://www.xmlvalidation.com/) as well. Removing spaces at the end of every module helped that. 
2. ```The Checkstyle rules file could not be parsed.</b><br>cannot initialize module TreeWalker - Unable to instantiate 'RedundantThrows' class, it is also not possible to instantiate it as com.puppycrawl.tools.checkstyle.checks.annotation.RedundantThrow``` error was the next error when i tried to import checkstyle.xml next time. I hade to remove ```RedundantThrow``` check because it's not working any more in Checkstyle 6.5 and above accordign to [Issue in checkstyle repo](https://github.com/checkstyle/checkstyle/issues/473) . 

After this two fixes i was able to import this xml into Intellij IDEA